### PR TITLE
[reminder] Config call should be awaited

### DIFF
--- a/reminder/reminder.py
+++ b/reminder/reminder.py
@@ -114,7 +114,7 @@ class Reminder(Cog):
             for reminder in user_config["reminders"]:
                 user = self.bot.get_user(user_id)
                 if user is None:
-                    self.config.remove(reminder)  # Delete the reminder if the user doesn't have a mutual server anymore
+                    await self.config.remove(reminder)  # Delete the reminder if the user doesn't have a mutual server anymore
                 else:
                     time_diff = datetime.datetime.fromtimestamp(reminder["end_time"]) - datetime.datetime.utcnow()
                     time = max(0.0, time_diff.total_seconds())


### PR DESCRIPTION
Resolves message on startup/cog load about removing users:
```
/.../Red/cogs/CogManager/cogs/reminder/reminder.py:117: RuntimeWarning: coroutine 'Value._get' was never awaited
  self.config.remove(reminder)  # Delete the reminder if the user doesn't have a mutual server anymore
```