### PR TITLE
[Birthdays] Paginate response into multiple embeds

### DIFF
--- a/birthdays/birthdays.py
+++ b/birthdays/birthdays.py
@@ -11,6 +11,7 @@ from redbot.core.bot import Red
 from redbot.core.config import Group
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.commands import Context, Cog
+from redbot.core.utils.chat_formatting import bold, pagify
 
 T_ = Translator("Birthdays", __file__)  # pygettext3 -Dnp locales birthdays.py
 
@@ -129,6 +130,7 @@ class Birthdays(Cog):
             bday_day_str = birthday.strftime("%d").lstrip("0")  # To remove the zero-capped
             await channel.send(self.BDAY_SET(bday_month_str + " " + bday_day_str))
 
+    @commands.cooldown(1, 60, commands.BucketType.channel)
     @bday.command(name="list")
     async def bday_list(self, ctx: Context):
         """Lists the birthdays for this server
@@ -138,7 +140,8 @@ class Birthdays(Cog):
         await self.clean_bdays()
         bdays = await self.get_guild_date_configs(message.guild.id)
         this_year = datetime.date.today().year
-        embed = discord.Embed(title=self.BDAY_LIST_TITLE(), color=discord.Colour.lighter_grey())
+        embed_list = []
+        msg = f"{bold(self.BDAY_LIST_TITLE())}\n"
         for k, g in itertools.groupby(sorted(datetime.datetime.fromordinal(int(o)) for o in bdays.keys()),
                                       lambda i: i.month):
             # Basically separates days with "\n" and people on the same day with ", "
@@ -148,8 +151,16 @@ class Birthdays(Cog):
                                           for u_id, year in bdays.get(str(date.toordinal()), {}).items())
                               for date in g if len(bdays.get(str(date.toordinal()))) > 0)
             if not value.isspace():  # Only contains whitespace when there's no birthdays in that month
-                embed.add_field(name=datetime.datetime(year=1, month=k, day=1).strftime("%B"), value=value)
-        await message.channel.send(embed=embed)
+                msg += f"{bold(datetime.datetime(year=1, month=k, day=1).strftime('%B'))}\n"
+                msg += f"{value}\n\n"
+
+        for page in pagify(msg, delims=["\n\n"], page_length=2000):
+            embed = discord.Embed(description=page, color=discord.Colour.lighter_grey())
+            embed_list.append(embed)
+
+        for i, em in enumerate(embed_list):
+            em.set_footer(text=f"Page {i + 1}/{len(embed_list)}")
+            await ctx.send(embed=em)
 
     # Utilities
     async def clean_bday(self, guild_id: int, guild_config: dict, user_id: int):

--- a/birthdays/birthdays.py
+++ b/birthdays/birthdays.py
@@ -140,7 +140,6 @@ class Birthdays(Cog):
         await self.clean_bdays()
         bdays = await self.get_guild_date_configs(message.guild.id)
         this_year = datetime.date.today().year
-        embed_list = []
         msg = f"{bold(self.BDAY_LIST_TITLE())}\n"
         for k, g in itertools.groupby(sorted(datetime.datetime.fromordinal(int(o)) for o in bdays.keys()),
                                       lambda i: i.month):
@@ -154,13 +153,11 @@ class Birthdays(Cog):
                 msg += f"{bold(datetime.datetime(year=1, month=k, day=1).strftime('%B'))}\n"
                 msg += f"{value}\n\n"
 
-        for page in pagify(msg, delims=["\n\n"], page_length=2000):
-            embed = discord.Embed(description=page, color=discord.Colour.lighter_grey())
-            embed_list.append(embed)
-
-        for i, em in enumerate(embed_list):
-            em.set_footer(text=f"Page {i + 1}/{len(embed_list)}")
-            await ctx.send(embed=em)
+        pages = list(pagify(msg, delims=["\n\n"], page_length=2000))
+        for i, em in enumerate(pages):
+            embed = discord.Embed(description=em, color=discord.Colour.lighter_grey())
+            embed.set_footer(text=f"Page {i + 1}/{len(pages)}")
+            await ctx.send(embed=embed)
 
     # Utilities
     async def clean_bday(self, guild_id: int, guild_config: dict, user_id: int):


### PR DESCRIPTION
This is a possible fix for #40, but it is also a style change. This brings all the birthday info into the embed description area for easy pagination, out of embed fields, so it may not be ideal... but it is easier than trying to determine length for various embed fields and get them sorted out to the right embed while staying under the 6k character cap. Added a cooldown per our discussion on the linked issue as well.