### PR TITLE
[react_roles] Fixed number of identifiers in call to config init_custom method

### DIFF
--- a/react_roles/react_roles.py
+++ b/react_roles/react_roles.py
@@ -94,7 +94,7 @@ class ReactRoles(Cog):
         unique_id = int(hashlib.sha512((self.__author__ + "@" + self.__class__.__name__).encode()).hexdigest(), 16)
         self.config = Config.get_conf(self, identifier=unique_id)
         if "init_custom" in dir(self.config):
-            self.config.init_custom(self.MESSAGE_GROUP, 1)
+            self.config.init_custom(self.MESSAGE_GROUP, 2)
         self.config.register_guild(links={})
         self.role_queue = asyncio.Queue()
         self.role_map = {}


### PR DESCRIPTION
**Description**
The init_custom call in the react_roles init specified 1 identifier instead of 2 (channel and message). This was causing an issue with the PostgreSQL backend (at least from what I can tell) when attempting to use the 'reactroles add' command. I [attached below](https://github.com/ZeLarpMaster/ZeCogsV3/files/6028090/react_roles.error.txt) the error it was throwing. Changing the identifier_count from 1 to 2 fixed this.

**Previous Error**
[react_roles error.txt](https://github.com/ZeLarpMaster/ZeCogsV3/files/6028090/react_roles.error.txt)

**Notes**
I spent a bit too long looking into Red's code thinking this was some weird behavior/issue with its PostgreSQL driver. It turned out to be a lot simpler than I was expecting.